### PR TITLE
DPDK patches for NICBench experiments on Intel ICE cards

### DIFF
--- a/app/test-flow-perf/actions_gen.c
+++ b/app/test-flow-perf/actions_gen.c
@@ -62,10 +62,7 @@ add_mark(struct rte_flow_action *actions,
 	static struct rte_flow_action_mark mark_action;
 	uint32_t counter = para.counter;
 
-	do {
-		/* Random values from 1 to 256 */
-		mark_action.id = (counter % 255) + 1;
-	} while (0);
+	mark_action.id = (counter % 255) + 1;
 
 	actions[actions_counter].type = RTE_FLOW_ACTION_TYPE_MARK;
 	actions[actions_counter].conf = &mark_action;

--- a/app/test-flow-perf/actions_gen.c
+++ b/app/test-flow-perf/actions_gen.c
@@ -29,6 +29,7 @@ struct additional_para {
 	uint32_t counter;
 	uint64_t encap_data;
 	uint64_t decap_data;
+	uint64_t rss_flags;
 };
 
 /* Storage for struct rte_flow_action_raw_encap including external data. */
@@ -121,7 +122,7 @@ add_rss(struct rte_flow_action *actions,
 		.conf = (struct rte_flow_action_rss){
 			.func = RTE_ETH_HASH_FUNCTION_DEFAULT,
 			.level = 0,
-			.types = GET_RSS_HF(),
+			.types = para.rss_flags,
 			.key_len = sizeof(rss_data->key),
 			.queue_num = para.queues_number,
 			.key = rss_data->key,
@@ -919,7 +920,7 @@ fill_target_flow_actions(struct rte_flow_action *actions)
 void
 fill_actions(struct rte_flow_action *actions, uint64_t *flow_actions,
 	uint32_t counter, uint16_t next_table, uint16_t hairpinq,
-	uint64_t encap_data, uint64_t decap_data)
+	uint64_t encap_data, uint64_t decap_data, uint64_t rss_flags)
 {
 	struct additional_para additional_para_data;
 	uint8_t actions_counter = 0;
@@ -941,6 +942,7 @@ fill_actions(struct rte_flow_action *actions, uint64_t *flow_actions,
 		.counter = counter,
 		.encap_data = encap_data,
 		.decap_data = decap_data,
+		.rss_flags = rss_flags,
 	};
 
 	if (hairpinq != 0) {

--- a/app/test-flow-perf/actions_gen.c
+++ b/app/test-flow-perf/actions_gen.c
@@ -62,7 +62,10 @@ add_mark(struct rte_flow_action *actions,
 	static struct rte_flow_action_mark mark_action;
 	uint32_t counter = para.counter;
 
-	mark_action.id = (counter % 255) + 1;
+    do {
+		/* Random values from 1 to 256 */
+		mark_action.id = (counter % 255) + 1;
+	} while (0);
 
 	actions[actions_counter].type = RTE_FLOW_ACTION_TYPE_MARK;
 	actions[actions_counter].conf = &mark_action;
@@ -491,7 +494,7 @@ add_set_ipv4_dscp(struct rte_flow_action *actions,
 	if (FIXED_VALUES)
 		dscp_value = 1;
 
-	/* Set dscp to random value each time */
+	/* Set dscp to r andom value each time */
 	dscp_value = dscp_value % 0xff;
 
 	set_dscp.dscp = dscp_value;

--- a/app/test-flow-perf/actions_gen.h
+++ b/app/test-flow-perf/actions_gen.h
@@ -21,6 +21,6 @@ void fill_target_flow_actions(struct rte_flow_action *actions);
 
 void fill_actions(struct rte_flow_action *actions, uint64_t *flow_actions,
 	uint32_t counter, uint16_t next_table, uint16_t hairpinq,
-	uint64_t encap_data, uint64_t decap_data);
+	uint64_t encap_data, uint64_t decap_data, uint64_t rss_flags);
 
 #endif /* FLOW_PERF_ACTION_GEN */

--- a/app/test-flow-perf/config.h
+++ b/app/test-flow-perf/config.h
@@ -25,6 +25,8 @@
 /* Items/Actions parameters */
 #define JUMP_ACTION_TABLE 2
 #define VLAN_VALUE 1
+#define TCP_PORT 80
+#define UDP_PORT 53
 #define VNI_VALUE 1
 #define META_DATA 1
 #define TAG_INDEX 0

--- a/app/test-flow-perf/config.h
+++ b/app/test-flow-perf/config.h
@@ -5,7 +5,7 @@
 #define FLOW_ITEM_MASK(_x) (UINT64_C(1) << _x)
 #define FLOW_ACTION_MASK(_x) (UINT64_C(1) << _x)
 #define FLOW_ATTR_MASK(_x) (UINT64_C(1) << _x)
-#define GET_RSS_HF() (ETH_RSS_IP | ETH_RSS_TCP)
+#define DEFAULT_RSS_HF (ETH_RSS_IP | ETH_RSS_TCP)
 
 /* Configuration */
 #define RXQ_NUM 4

--- a/app/test-flow-perf/flow_gen.c
+++ b/app/test-flow-perf/flow_gen.c
@@ -78,6 +78,7 @@ generate_flow(uint16_t port_id,
 	uint16_t hairpinq,
 	uint64_t encap_data,
 	uint64_t decap_data,
+	uint64_t rss_flags,
 	struct rte_flow_error *error)
 {
 	struct rte_flow_attr attr;
@@ -93,7 +94,7 @@ generate_flow(uint16_t port_id,
 
 	fill_actions(actions, flow_actions,
 		outer_ip_src, next_table, hairpinq,
-		encap_data, decap_data);
+		encap_data, decap_data, rss_flags);
 
 	fill_items(items, flow_items, outer_ip_src);
 

--- a/app/test-flow-perf/flow_gen.c
+++ b/app/test-flow-perf/flow_gen.c
@@ -18,7 +18,7 @@
 
 static void
 fill_attributes(struct rte_flow_attr *attr,
-	uint64_t *flow_attrs, uint16_t group)
+	uint64_t *flow_attrs, uint16_t group, uint16_t priority)
 {
 	uint8_t i;
 	for (i = 0; i < MAX_ATTRS_NUM; i++) {
@@ -32,10 +32,11 @@ fill_attributes(struct rte_flow_attr *attr,
 			attr->transfer = 1;
 	}
 	attr->group = group;
+	attr->priority = priority;
 }
 
 static void
-fill_target_flow_attributes(struct rte_flow_attr *attr, uint16_t group)
+fill_target_flow_attributes(struct rte_flow_attr *attr, uint16_t group, uint16_t priority)
 {
 	if (!attr) {
 		return;
@@ -43,11 +44,12 @@ fill_target_flow_attributes(struct rte_flow_attr *attr, uint16_t group)
 
 	attr->ingress = 1;
 	attr->group = group;
+	attr->priority = priority;
 }
 
 struct rte_flow *
 generate_target_flow(uint16_t port_id,
-	uint16_t group,
+	uint16_t group, uint16_t priority,
 	struct rte_flow_error *error)
 {
 	struct rte_flow_attr attr;
@@ -59,7 +61,7 @@ generate_target_flow(uint16_t port_id,
 	memset(items, 0, sizeof(items));
 	memset(actions, 0, sizeof(actions));
 
-	fill_target_flow_attributes(&attr, group);
+	fill_target_flow_attributes(&attr, group, priority);
 	fill_target_flow_items(items);
 	fill_target_flow_actions(actions);
 
@@ -70,6 +72,7 @@ generate_target_flow(uint16_t port_id,
 struct rte_flow *
 generate_flow(uint16_t port_id,
 	uint16_t group,
+	uint16_t priority,
 	uint64_t *flow_attrs,
 	uint64_t *flow_items,
 	uint64_t *flow_actions,
@@ -90,7 +93,7 @@ generate_flow(uint16_t port_id,
 	memset(actions, 0, sizeof(actions));
 	memset(&attr, 0, sizeof(struct rte_flow_attr));
 
-	fill_attributes(&attr, flow_attrs, group);
+	fill_attributes(&attr, flow_attrs, group, priority);
 
 	fill_actions(actions, flow_actions,
 		outer_ip_src, next_table, hairpinq,
@@ -105,6 +108,7 @@ int
 update_flow(struct rte_flow *flow,
 	uint16_t port_id,
 	uint16_t group,
+	uint16_t priority,
 	uint64_t *flow_attrs,
 	uint64_t *flow_items,
 	uint64_t *flow_actions,

--- a/app/test-flow-perf/flow_gen.h
+++ b/app/test-flow-perf/flow_gen.h
@@ -25,12 +25,13 @@
 
 struct rte_flow *
 generate_target_flow(uint16_t port_id,
-	uint16_t group,
+	uint16_t group, uint16_t priority,
 	struct rte_flow_error *error);
 
 struct rte_flow *
 generate_flow(uint16_t port_id,
 	uint16_t group,
+	uint16_t priority,
 	uint64_t *flow_attrs,
 	uint64_t *flow_items,
 	uint64_t *flow_actions,
@@ -46,6 +47,7 @@ int
 update_flow(struct rte_flow *flow,
 	uint16_t port_id,
 	uint16_t group,
+	uint16_t priority,
 	uint64_t *flow_attrs,
 	uint64_t *flow_items,
 	uint64_t *flow_actions,

--- a/app/test-flow-perf/flow_gen.h
+++ b/app/test-flow-perf/flow_gen.h
@@ -39,6 +39,7 @@ generate_flow(uint16_t port_id,
 	uint16_t hairpinq,
 	uint64_t encap_data,
 	uint64_t decap_data,
+	uint64_t rss_flags,
 	struct rte_flow_error *error);
 
 int

--- a/app/test-flow-perf/items_gen.c
+++ b/app/test-flow-perf/items_gen.c
@@ -285,6 +285,28 @@ add_gtp(struct rte_flow_item *items,
 }
 
 static void
+add_gtpu(struct rte_flow_item *items,
+	uint8_t items_counter,
+	__rte_unused struct additional_para para)
+{
+	static struct rte_flow_item_gtp gtpu_spec;
+	static struct rte_flow_item_gtp gtpu_mask;
+
+	uint32_t teid_value;
+
+	teid_value = TEID_VALUE;
+
+	memset(&gtpu_spec, 0, sizeof(struct rte_flow_item_gtp));
+	memset(&gtpu_mask, 0, sizeof(struct rte_flow_item_gtp));
+
+	gtpu_spec.teid = RTE_BE32(teid_value);
+	gtpu_mask.teid = RTE_BE32(0xffffffff);
+
+	items[items_counter].type = RTE_FLOW_ITEM_TYPE_GTPU;
+	items[items_counter].spec = &gtpu_spec;
+	items[items_counter].mask = &gtpu_mask;
+}
+static void
 add_meta_data(struct rte_flow_item *items,
 	uint8_t items_counter,
 	__rte_unused struct additional_para para)
@@ -452,6 +474,10 @@ fill_items(struct rte_flow_item *items,
 		{
 			.mask = RTE_FLOW_ITEM_TYPE_GTP,
 			.funct = add_gtp,
+		},
+		{
+			.mask = RTE_FLOW_ITEM_TYPE_GTPU,
+			.funct = add_gtpu,
 		},
 		{
 			.mask = RTE_FLOW_ITEM_TYPE_ICMP,

--- a/app/test-flow-perf/items_gen.c
+++ b/app/test-flow-perf/items_gen.c
@@ -118,6 +118,91 @@ add_ipv6(struct rte_flow_item *items,
 }
 
 static void
+add_ah(struct rte_flow_item *items,
+	uint8_t items_counter,
+	struct additional_para para)
+{
+	static struct rte_flow_item_ah ah_spec;
+	static struct rte_flow_item_ah ah_mask;
+
+	uint16_t ah_value = para.src_ip;
+
+	memset(&ah_spec, 0, sizeof(struct rte_flow_item_ah));
+	memset(&ah_mask, 0, sizeof(struct rte_flow_item_ah));
+
+	ah_spec.spi = RTE_BE16(ah_value);
+	ah_mask.spi = RTE_BE16(0xffff);
+
+	items[items_counter].type = RTE_FLOW_ITEM_TYPE_AH;
+	items[items_counter].spec = &ah_spec;
+	items[items_counter].mask = &ah_mask;
+}
+
+static void
+add_esp(struct rte_flow_item *items,
+	uint8_t items_counter,
+	struct additional_para para)
+{
+	static struct rte_flow_item_esp esp_spec;
+	static struct rte_flow_item_esp esp_mask;
+
+	uint16_t esp_value = para.src_ip;
+
+	memset(&esp_spec, 0, sizeof(struct rte_flow_item_esp));
+	memset(&esp_mask, 0, sizeof(struct rte_flow_item_esp));
+
+	esp_spec.hdr.spi = RTE_BE16(esp_value);
+	esp_mask.hdr.spi = RTE_BE16(0xffff);
+
+	items[items_counter].type = RTE_FLOW_ITEM_TYPE_ESP;
+	items[items_counter].spec = &esp_spec;
+	items[items_counter].mask = &esp_mask;
+}
+
+static void
+add_pppoes(struct rte_flow_item *items,
+	uint8_t items_counter,
+	struct additional_para para)
+{
+	static struct rte_flow_item_pppoe pppoes_spec;
+	static struct rte_flow_item_pppoe pppoes_mask;
+
+	uint16_t pppoes_value = para.src_ip;
+
+	memset(&pppoes_spec, 0, sizeof(struct rte_flow_item_pppoe));
+	memset(&pppoes_mask, 0, sizeof(struct rte_flow_item_pppoe));
+
+	pppoes_spec.session_id = RTE_BE16(pppoes_value);
+	pppoes_mask.session_id = RTE_BE16(0xffff);
+
+	items[items_counter].type = RTE_FLOW_ITEM_TYPE_PPPOES;
+	items[items_counter].spec = &pppoes_spec;
+	items[items_counter].mask = &pppoes_mask;
+}
+
+static void
+add_l2tpv3oip(struct rte_flow_item *items,
+	uint8_t items_counter,
+	struct additional_para para)
+{
+	static struct rte_flow_item_l2tpv3oip l2tpv3oip_spec;
+	static struct rte_flow_item_l2tpv3oip l2tpv3oip_mask;
+
+	//uint16_t l2tpv3oip_value = l2tpv3oip_VALUE;
+	uint16_t l2tpv3oip_value = para.src_ip;
+
+	memset(&l2tpv3oip_spec, 0, sizeof(struct rte_flow_item_l2tpv3oip));
+	memset(&l2tpv3oip_mask, 0, sizeof(struct rte_flow_item_l2tpv3oip));
+
+	l2tpv3oip_spec.session_id = RTE_BE16(l2tpv3oip_value);
+	l2tpv3oip_mask.session_id = RTE_BE16(0xffff);
+
+	items[items_counter].type = RTE_FLOW_ITEM_TYPE_L2TPV3OIP;
+	items[items_counter].spec = &l2tpv3oip_spec;
+	items[items_counter].mask = &l2tpv3oip_mask;
+}
+
+static void
 add_tcp(struct rte_flow_item *items,
 	uint8_t items_counter,
 	__rte_unused struct additional_para para)
@@ -439,6 +524,22 @@ fill_items(struct rte_flow_item *items,
 		{
 			.mask = RTE_FLOW_ITEM_TYPE_VLAN,
 			.funct = add_vlan,
+		},
+		{
+			.mask = RTE_FLOW_ITEM_TYPE_ESP,
+			.funct = add_esp,
+		},
+		{
+			.mask = RTE_FLOW_ITEM_TYPE_AH,
+			.funct = add_ah,
+		},
+		{
+			.mask = RTE_FLOW_ITEM_TYPE_L2TPV3OIP,
+			.funct = add_l2tpv3oip,
+		},
+		{
+			.mask = RTE_FLOW_ITEM_TYPE_PPPOES,
+			.funct = add_pppoes,
 		},
 		{
 			.mask = RTE_FLOW_ITEM_TYPE_IPV4,

--- a/app/test-flow-perf/items_gen.c
+++ b/app/test-flow-perf/items_gen.c
@@ -36,18 +36,19 @@ add_ether(struct rte_flow_item *items,
 static void
 add_vlan(struct rte_flow_item *items,
 	uint8_t items_counter,
-	__rte_unused struct additional_para para)
+	struct additional_para para)
 {
 	static struct rte_flow_item_vlan vlan_spec;
 	static struct rte_flow_item_vlan vlan_mask;
 
-	uint16_t vlan_value = VLAN_VALUE;
+	//uint16_t vlan_value = VLAN_VALUE;
+	uint16_t vlan_value = para.src_ip;
 
 	memset(&vlan_spec, 0, sizeof(struct rte_flow_item_vlan));
 	memset(&vlan_mask, 0, sizeof(struct rte_flow_item_vlan));
 
 	vlan_spec.tci = RTE_BE16(vlan_value);
-	vlan_mask.tci = RTE_BE16(0x05ff);
+	vlan_mask.tci = RTE_BE16(0xffff);
 
 	items[items_counter].type = RTE_FLOW_ITEM_TYPE_VLAN;
 	items[items_counter].spec = &vlan_spec;

--- a/app/test-flow-perf/items_gen.c
+++ b/app/test-flow-perf/items_gen.c
@@ -49,7 +49,6 @@ add_vlan(struct rte_flow_item *items,
 	vlan_spec.tci = RTE_BE16(vlan_value);
 	vlan_mask.tci = RTE_BE16(0x05ff);
 
-	printf("Added VLAN with id %i at index %i\n", vlan_value, items_counter);
 	items[items_counter].type = RTE_FLOW_ITEM_TYPE_VLAN;
 	items[items_counter].spec = &vlan_spec;
 	items[items_counter].mask = &vlan_mask;
@@ -68,7 +67,6 @@ add_ipv4(struct rte_flow_item *items,
 	ipv4_spec.hdr.src_addr = RTE_BE32(para.src_ip);
 	ipv4_mask.hdr.src_addr = RTE_BE32(0xffffffff);
 
-	printf("Added IPv4 with src %i at index %i\n",para.src_ip, items_counter);
 	items[items_counter].type = RTE_FLOW_ITEM_TYPE_IPV4;
 	items[items_counter].spec = &ipv4_spec;
 	items[items_counter].mask = &ipv4_mask;

--- a/app/test-flow-perf/items_gen.c
+++ b/app/test-flow-perf/items_gen.c
@@ -47,8 +47,9 @@ add_vlan(struct rte_flow_item *items,
 	memset(&vlan_mask, 0, sizeof(struct rte_flow_item_vlan));
 
 	vlan_spec.tci = RTE_BE16(vlan_value);
-	vlan_mask.tci = RTE_BE16(0xffff);
+	vlan_mask.tci = RTE_BE16(0x05ff);
 
+	printf("Added VLAN with id %i at index %i\n", vlan_value, items_counter);
 	items[items_counter].type = RTE_FLOW_ITEM_TYPE_VLAN;
 	items[items_counter].spec = &vlan_spec;
 	items[items_counter].mask = &vlan_mask;
@@ -67,6 +68,7 @@ add_ipv4(struct rte_flow_item *items,
 	ipv4_spec.hdr.src_addr = RTE_BE32(para.src_ip);
 	ipv4_mask.hdr.src_addr = RTE_BE32(0xffffffff);
 
+	printf("Added IPv4 with src %i at index %i\n",para.src_ip, items_counter);
 	items[items_counter].type = RTE_FLOW_ITEM_TYPE_IPV4;
 	items[items_counter].spec = &ipv4_spec;
 	items[items_counter].mask = &ipv4_mask;
@@ -127,6 +129,8 @@ add_tcp(struct rte_flow_item *items,
 	memset(&tcp_spec, 0, sizeof(struct rte_flow_item_tcp));
 	memset(&tcp_mask, 0, sizeof(struct rte_flow_item_tcp));
 
+	tcp_spec.hdr.src_port = TCP_PORT;
+	tcp_mask.hdr.src_port = 0xff;
 	items[items_counter].type = RTE_FLOW_ITEM_TYPE_TCP;
 	items[items_counter].spec = &tcp_spec;
 	items[items_counter].mask = &tcp_mask;
@@ -143,6 +147,8 @@ add_udp(struct rte_flow_item *items,
 	memset(&udp_spec, 0, sizeof(struct rte_flow_item_udp));
 	memset(&udp_mask, 0, sizeof(struct rte_flow_item_udp));
 
+	udp_spec.hdr.src_port = UDP_PORT;
+	udp_mask.hdr.src_port = 0xff;
 	items[items_counter].type = RTE_FLOW_ITEM_TYPE_UDP;
 	items[items_counter].spec = &udp_spec;
 	items[items_counter].mask = &udp_mask;

--- a/app/test-flow-perf/main.c
+++ b/app/test-flow-perf/main.c
@@ -40,7 +40,7 @@
 
 #define MAX_ITERATIONS             100
 #define DEFAULT_RULES_COUNT    4000000
-#define DEFAULT_RULES_BATCH        1000
+#define DEFAULT_RULES_BATCH       1000
 #define DEFAULT_GROUP                0
 
 struct rte_flow *flow;
@@ -727,13 +727,10 @@ args_parse(int argc, char **argv)
 			if (strcmp(lgopts[opt_idx].name,
 					"rules-batch") == 0) {
 				n = atoi(optarg);
-				if (n >= DEFAULT_RULES_BATCH)
-					rules_batch = n;
-				else {
+				if (n < DEFAULT_RULES_BATCH)
 					printf("\n\nrules_batch should be >= %d\n",
 						DEFAULT_RULES_BATCH);
-					rte_exit(EXIT_SUCCESS, " ");
-				}
+				rules_batch = n;
 			}
 			if (strcmp(lgopts[opt_idx].name,
 					"rules-count") == 0) {

--- a/app/test-flow-perf/main.c
+++ b/app/test-flow-perf/main.c
@@ -152,6 +152,7 @@ usage(char *progname)
 	printf("  --gre: add gre layer in flow items\n");
 	printf("  --geneve: add geneve layer in flow items\n");
 	printf("  --gtp: add gtp layer in flow items\n");
+	printf("  --gtpu: add gtp-u layer in flow items\n");
 	printf("  --meta: add meta layer in flow items\n");
 	printf("  --tag: add tag layer in flow items\n");
 	printf("  --icmpv4: add icmpv4 layer in flow items\n");
@@ -297,6 +298,12 @@ args_parse(int argc, char **argv)
 		{
 			.str = "gtp",
 			.mask = FLOW_ITEM_MASK(RTE_FLOW_ITEM_TYPE_GTP),
+			.map = &flow_items[0],
+			.map_idx = &items_idx
+		},
+		{
+			.str = "gtpu",
+			.mask = FLOW_ITEM_MASK(RTE_FLOW_ITEM_TYPE_GTPU),
 			.map = &flow_items[0],
 			.map_idx = &items_idx
 		},
@@ -584,6 +591,7 @@ args_parse(int argc, char **argv)
 		{ "gre",                        0, 0, 0 },
 		{ "geneve",                     0, 0, 0 },
 		{ "gtp",                        0, 0, 0 },
+		{ "gtpu",                       0, 0, 0 },
 		{ "meta",                       0, 0, 0 },
 		{ "tag",                        0, 0, 0 },
 		{ "icmpv4",                     0, 0, 0 },

--- a/app/test-flow-perf/main.c
+++ b/app/test-flow-perf/main.c
@@ -127,7 +127,7 @@ usage(char *progname)
 		" hexadecimal format, default is 0x%llx\n", DEFAULT_RSS_HF);
 	printf("  --disable-capa=N: device capabilities to disable,"
 		" hexadecimal format, default is 0x%x (enable all)\n", 0);
-	printf(" --disable-fdir-config: do not configure the fdir.\n");
+	printf("  --disable-fdir-config: do not configure the fdir.\n");
 
 	printf("To set flow attributes:\n");
 	printf("  --ingress: set ingress attribute in flows\n");
@@ -793,10 +793,13 @@ args_parse(int argc, char **argv)
 			if (strcmp(lgopts[opt_idx].name,
 					"rules-batch") == 0) {
 				n = atoi(optarg);
-				if (n < DEFAULT_RULES_BATCH)
+				if (n >= DEFAULT_RULES_BATCH)
+					rules_batch = n;
+				else {
 					printf("\n\nrules_batch should be >= %d\n",
 						DEFAULT_RULES_BATCH);
-				rules_batch = n;
+					rte_exit(EXIT_SUCCESS, " ");
+				}
 			}
 			if (strcmp(lgopts[opt_idx].name,
 					"rules-count") == 0) {
@@ -950,7 +953,7 @@ update_flows(int port_id, struct rte_flow **flow_list)
 	for (i = 0; i < MAX_ITERATIONS; i++)
 		cpu_time_per_iter[i] = -1;
 
-    int tot = rules_count;
+    uint32_t tot = rules_count;
 
     int max = rules_batch;
 	/* Update Rate */
@@ -1135,9 +1138,11 @@ flows_handler(void)
 			 * group 0 eth / end actions jump group <flow_group>
 			 *
 			 */
-			flow = generate_flow(port_id, 0, flow_attrs,
-				global_items, global_actions,
-				flow_group, flow_priority, 0, 0, 0, 0, rss_flags, &error);
+			flow = generate_flow(port_id, 0 , flow_priority,
+				flow_attrs, global_items, global_actions,
+				flow_group, 0, 0, 0, 0,
+				rss_flags,
+				&error);
 
 			if (flow == NULL) {
 				print_flow_error(flow_index, error);

--- a/app/test-flow-perf/main.c
+++ b/app/test-flow-perf/main.c
@@ -42,7 +42,7 @@
 #define DEFAULT_RULES_COUNT    4000000
 #define DEFAULT_RULES_BATCH       1000
 #define DEFAULT_GROUP                0
-#define DEFAULT_PRIORITY	     0
+#define DEFAULT_PRIORITY             0
 
 struct rte_flow *flow;
 static uint8_t flow_group;
@@ -136,7 +136,7 @@ usage(char *progname)
 	printf("  --group=N: set group for all flows,"
 		" default is %d\n", DEFAULT_GROUP);
 
-	printf("  --priority=N: set priorityfor all flows,"
+	printf("  --priority=N: set priority for all flows,"
 		" default is %d\n", DEFAULT_PRIORITY);
 
 
@@ -151,6 +151,10 @@ usage(char *progname)
 	printf("  --vxlan-gpe: add vxlan-gpe layer in flow items\n");
 	printf("  --gre: add gre layer in flow items\n");
 	printf("  --geneve: add geneve layer in flow items\n");
+	printf("  --ah: add AH layer in flow items\n");
+	printf("  --esp: add ESP layer in flow items\n");
+	printf("  --pppoes: add PPPoEs layer in flow items\n");
+	printf("  --l2tpv3oip: add l2tpv3oip layer in flow items\n");
 	printf("  --gtp: add gtp layer in flow items\n");
 	printf("  --gtpu: add gtp-u layer in flow items\n");
 	printf("  --meta: add meta layer in flow items\n");
@@ -256,6 +260,30 @@ args_parse(int argc, char **argv)
 		{
 			.str = "vlan",
 			.mask = FLOW_ITEM_MASK(RTE_FLOW_ITEM_TYPE_VLAN),
+			.map = &flow_items[0],
+			.map_idx = &items_idx
+		},
+		{
+			.str = "ah",
+			.mask = FLOW_ITEM_MASK(RTE_FLOW_ITEM_TYPE_AH),
+			.map = &flow_items[0],
+			.map_idx = &items_idx
+		},
+		{
+			.str = "esp",
+			.mask = FLOW_ITEM_MASK(RTE_FLOW_ITEM_TYPE_ESP),
+			.map = &flow_items[0],
+			.map_idx = &items_idx
+		},
+		{
+			.str = "pppoes",
+			.mask = FLOW_ITEM_MASK(RTE_FLOW_ITEM_TYPE_PPPOES),
+			.map = &flow_items[0],
+			.map_idx = &items_idx
+		},
+		{
+			.str = "l2tpv3oip",
+			.mask = FLOW_ITEM_MASK(RTE_FLOW_ITEM_TYPE_L2TPV3OIP),
 			.map = &flow_items[0],
 			.map_idx = &items_idx
 		},
@@ -582,6 +610,10 @@ args_parse(int argc, char **argv)
 		/* Items */
 		{ "ether",                      0, 0, 0 },
 		{ "vlan",                       0, 0, 0 },
+		{ "ah",                         0, 0, 0 },
+		{ "esp",                        0, 0, 0 },
+		{ "pppoes",                     0, 0, 0 },
+		{ "l2tpv3oip",                  0, 0, 0 },
 		{ "ipv4",                       0, 0, 0 },
 		{ "ipv6",                       0, 0, 0 },
 		{ "tcp",                        0, 0, 0 },
@@ -1547,18 +1579,19 @@ init_port(void)
 		port_conf.txmode.offloads &= dev_info.tx_offload_capa;
 		port_conf.rxmode.offloads &= dev_info.rx_offload_capa;
 
-		printf("Offloads would be  RX: 0x%lx, TX: 0x%lx. Applying disable mask 0x%lx"
+		printf("Offloads would be  RX: 0x%lx, TX: 0x%lx. Applying disable mask 0x%lx\n",
 		port_conf.rxmode.offloads,
 		port_conf.txmode.offloads,
-		~disable_capa);
+		disable_capa);
 
-		port_conf.txmode.offloads &= ~disable_capa;
-		port_conf.rxmode.offloads &= ~disable_capa;
-
-		printf("After mask, offloads are RX: 0x%lx, TX: 0x%lx\n",
-		port_conf.rxmode.offloads,
-		port_conf.txmode.offloads);
-
+		if (disable_capa != 0)
+		{
+			port_conf.txmode.offloads &= ~disable_capa;
+			port_conf.rxmode.offloads &= ~disable_capa;
+			printf("After mask, offloads are RX: 0x%lx, TX: 0x%lx\n",
+			port_conf.rxmode.offloads,
+			port_conf.txmode.offloads);
+		}
 		printf(":: initializing port: %d\n", port_id);
 
 		ret = rte_eth_dev_configure(port_id, nr_queues,

--- a/app/test-flow-perf/main.c
+++ b/app/test-flow-perf/main.c
@@ -38,7 +38,7 @@
 #include "config.h"
 #include "flow_gen.h"
 
-#define MAX_ITERATIONS             100
+#define MAX_ITERATIONS          400000
 #define DEFAULT_RULES_COUNT    4000000
 #define DEFAULT_RULES_BATCH       1000
 #define DEFAULT_GROUP                0
@@ -791,25 +791,14 @@ args_parse(int argc, char **argv)
 			}
 			/* Control */
 			if (strcmp(lgopts[opt_idx].name,
-					"rules-batch") == 0) {
-				n = atoi(optarg);
-				if (n >= DEFAULT_RULES_BATCH)
-					rules_batch = n;
-				else {
-					printf("\n\nrules_batch should be >= %d\n",
-						DEFAULT_RULES_BATCH);
-					rte_exit(EXIT_SUCCESS, " ");
-				}
-			}
-			if (strcmp(lgopts[opt_idx].name,
 					"rules-count") == 0) {
-				n = atoi(optarg);
-				if (n >= (int) rules_batch)
-					rules_count = n;
-				else {
-					printf("\n\nrules_count should be >= %d\n",
-						rules_batch);
-				}
+				rules_count = atoi(optarg);
+			}
+
+
+			if (strcmp(lgopts[opt_idx].name,
+					"rules-batch") == 0) {
+				rules_batch = atoi(optarg);
 			}
 			if (strcmp(lgopts[opt_idx].name,
 					"dump-iterations") == 0)
@@ -870,6 +859,17 @@ args_parse(int argc, char **argv)
 			rte_exit(EXIT_SUCCESS, "Invalid option\n");
 			break;
 		}
+	}
+	if ( rules_count < rules_batch)
+	{
+		printf("\n\nrules-count cannot be < rules-batch!\n");
+		rte_exit(EXIT_SUCCESS, "rules-batch > rules-count");
+	}
+	if ( rules_count / rules_batch > MAX_ITERATIONS)
+	{
+		printf("\n\nCannot handle %i / %i = %i iterations! Reduce rules-count or increase rules-batch.\n",
+				rules_count, rules_batch, rules_count / rules_batch);
+		rte_exit(EXIT_SUCCESS, "Too many iterations\n");
 	}
 	printf("end_flow\n");
 }

--- a/drivers/common/mlx5/linux/meson.build
+++ b/drivers/common/mlx5/linux/meson.build
@@ -174,6 +174,8 @@ has_sym_args = [
 	'RDMA_NLDEV_ATTR_NDEV_INDEX' ],
 	[ 'HAVE_MLX5_DR_FLOW_DUMP', 'infiniband/mlx5dv.h',
 	'mlx5dv_dump_dr_domain'],
+	[ 'HAVE_MLX5_DR_FLOW_UPDATE', 'infiniband/mlx5dv.h',
+	'mlx5dv_dr_rule_update'],
 	[ 'HAVE_MLX5_DR_CREATE_ACTION_FLOW_SAMPLE', 'infiniband/mlx5dv.h',
 	'mlx5dv_dr_action_create_flow_sampler'],
 	[ 'HAVE_MLX5DV_DR_MEM_RECLAIM', 'infiniband/mlx5dv.h',

--- a/drivers/common/mlx5/linux/mlx5_glue.c
+++ b/drivers/common/mlx5/linux/mlx5_glue.c
@@ -623,8 +623,19 @@ mlx5_glue_dv_update_flow(void *flow_id,
 			 void *actions[])
 {
 #ifdef HAVE_MLX5DV_DR
-	return mlx5dv_dr_rule_update(flow_id, match_value, num_actions,
-				     (struct mlx5dv_dr_action **)actions);
+#   ifdef HAVE_MLX5_DR_FLOW_UPDATE
+#	pragma message "Compiling mlx5 driver with rule update support"
+		return mlx5dv_dr_rule_update(flow_id, match_value, num_actions,
+						 (struct mlx5dv_dr_action **)actions);
+#   else
+#	pragma message "Compiling mlx5 driver without rule update support."
+	// We don't want compilation to fail if update action is not implemented.
+	(void)flow_id;
+	(void)match_value;
+	(void)num_actions;
+    (void)actions;
+	return -1;
+#   endif
 #else
 	(void)flow_id;
 	(void)match_value;

--- a/drivers/common/mlx5/linux/mlx5_glue.h
+++ b/drivers/common/mlx5/linux/mlx5_glue.h
@@ -26,7 +26,8 @@
 #define MLX5_GLUE_VERSION ""
 #endif
 
-#define dbg(args...)
+//#define dbg(...) printf(__VA_ARGS__)
+#define dbg(...) while(0) {}
 
 #ifndef HAVE_IBV_DEVICE_COUNTERS_SET_V42
 struct ibv_counter_set;

--- a/drivers/net/mlx5/mlx5_flow_dv.c
+++ b/drivers/net/mlx5/mlx5_flow_dv.c
@@ -10033,7 +10033,7 @@ flow_dv_translate(struct rte_eth_dev *dev,
 						(error, errno,
 						 RTE_FLOW_ERROR_TYPE_ACTION,
 						 NULL,
-						 "cannot create jump action.");
+						 "cannot create jump action, table does not exist.");
 			if (flow_dv_jump_tbl_resource_register
 			    (dev, tbl, dev_flow, error)) {
 				flow_dv_tbl_resource_release(MLX5_SH(dev), tbl);
@@ -10041,7 +10041,7 @@ flow_dv_translate(struct rte_eth_dev *dev,
 						(error, errno,
 						 RTE_FLOW_ERROR_TYPE_ACTION,
 						 NULL,
-						 "cannot create jump action.");
+						 "cannot create jump action, cannot register ressource.");
 			}
 			dev_flow->dv.actions[actions_n++] =
 					dev_flow->dv.jump->action;


### PR DESCRIPTION
Mainly additions to test-flow-perf, supporting more matches and further options that may need to be set when working with Intel E810 cards and DPDK recommended version of the ICE driver,  which doesn't support all the default settings hardcoded in the program.